### PR TITLE
Don't save models to disk when refreshing.

### DIFF
--- a/lib/ruby_llm/models.rb
+++ b/lib/ruby_llm/models.rb
@@ -40,7 +40,6 @@ module RubyLLM
 
         all = (preserved + configured.flat_map(&:list_models)).sort_by(&:id)
         @instance = new(all)
-        @instance.save_models
         @instance
       end
 


### PR DESCRIPTION
Fixes issues in production with read only filesystems.